### PR TITLE
Update vLLM config to use llama-3.2-1b-w8a8

### DIFF
--- a/gold/llm_config.yaml
+++ b/gold/llm_config.yaml
@@ -1,5 +1,5 @@
 base_url_env: "VLLM_BASE_URL"
-model: "gpt-oss-20b"
+model: "llama-3.2-1b-w8a8"
 api_key_env: "VLLM_API_KEY"
 temperature: 0.3
 max_tokens: 800


### PR DESCRIPTION
## Summary
- update the vLLM mining configuration to default to the llama-3.2-1b-w8a8 model

## Testing
- PYTHONPATH=. pytest *(fails: ProxyError when attempting to download hf-internal-testing/llama-tokenizer in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cead4d905c8333835ccc3224676cac