### PR TITLE
Improve offline robustness and gold utilities

### DIFF
--- a/chunking/driver.py
+++ b/chunking/driver.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Sequence, Tuple
 
 from env_loader import load_dotenv_once
 
-from chunking.semantic_chunker import semantic_segments
+import chunking.semantic_chunker as semantic_chunker
 from chunking.segmenter import segment_page
 from chunking.types import Block, Chunk
 from chunking.packer import get_tokenizer, pack_blocks
@@ -60,7 +60,7 @@ def _semantic_or_fixed_blocks(
     if not semantic_enabled or table_heavy:
         return base_blocks, "fixed"
 
-    segments = semantic_segments(text, model_name=model_name)
+    segments = semantic_chunker.semantic_segments(text, model_name=model_name)
     if not segments:
         return base_blocks, "fixed"
 

--- a/gold/quality.py
+++ b/gold/quality.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import math
+import random
 import re
-from typing import Iterable, List, Sequence, Set
+from collections import defaultdict
+from typing import Dict, Iterable, List, Mapping, Sequence, Set, Tuple
 
 _STOPWORDS: Set[str] = {
     "a",
@@ -85,26 +88,55 @@ def detect_wh(q: str) -> str:
     return "what"
 
 
-def is_entity_anchored(question: str, answer_text: str, window_text: str) -> bool:
-    q_tokens = [tok for tok in _tokenize(question) if tok not in _STOPWORDS]
+def is_entity_anchored(
+    question: str,
+    anchor: Mapping[str, str] | str,
+    window_text: str | None = None,
+) -> bool:
+    """Determine whether a question is grounded in a known entity."""
+
+    q_tokens = {tok for tok in _tokenize(question) if tok not in _STOPWORDS}
     if not q_tokens:
         return False
-    answer_tokens = [tok for tok in _tokenize(answer_text) if tok not in _STOPWORDS]
-    overlap = set(q_tokens) & set(answer_tokens)
-    if overlap:
-        return True
-    # Fall back to local context around the first occurrence of the answer
-    answer_norm = answer_text.strip().lower()
-    if not answer_norm:
+
+    if isinstance(anchor, Mapping):
+        slots = anchor
+        anchor_tokens: Set[str] = set()
+        for key in (
+            "term",
+            "topic",
+            "acronym",
+            "metric",
+            "entity_type",
+            "process",
+            "decision",
+            "event",
+            "responsibility",
+            "subject",
+            "doc_name",
+            "heading",
+            "section",
+            "scope",
+        ):
+            value = slots.get(key)
+            if value:
+                anchor_tokens.update(_tokenize(value))
+        if not anchor_tokens:
+            for value in slots.values():
+                anchor_tokens.update(_tokenize(value))
+        anchor_tokens = {tok for tok in anchor_tokens if tok not in _STOPWORDS}
+        if not anchor_tokens:
+            return False
+        return bool(q_tokens & anchor_tokens)
+
+    answer_text = str(anchor or "")
+    window = window_text or ""
+    anchor_tokens = {
+        tok for tok in _tokenize(answer_text + " " + window) if tok not in _STOPWORDS
+    }
+    if not anchor_tokens:
         return False
-    idx = window_text.lower().find(answer_norm)
-    if idx == -1:
-        return False
-    radius = 100
-    start = max(0, idx - radius)
-    end = min(len(window_text), idx + len(answer_text) + radius)
-    context_tokens = [tok for tok in _tokenize(window_text[start:end]) if tok not in _STOPWORDS]
-    return bool(set(q_tokens) & set(context_tokens))
+    return bool(q_tokens & anchor_tokens)
 
 
 def has_banned_opening(question: str, banned: Sequence[str]) -> bool:
@@ -119,6 +151,12 @@ def no_vague_pronoun(question: str) -> bool:
     return tokens[0] not in _PRONOUN_HEADS
 
 
+def no_vague_pronouns(question: str) -> bool:
+    """Backward-compatible alias for ``no_vague_pronoun``."""
+
+    return no_vague_pronoun(question)
+
+
 def readability_bounds(question: str, min_len: int = 8, max_len: int = 160) -> bool:
     stripped = question.strip()
     if not stripped.endswith("?"):
@@ -127,3 +165,163 @@ def readability_bounds(question: str, min_len: int = 8, max_len: int = 160) -> b
         return False
     words = stripped.split()
     return len(words) >= 3
+
+
+def answerability_check(
+    page_text: str,
+    answerspan: Tuple[int, int],
+    question: str,
+    slots: Mapping[str, str] | None,
+) -> bool:
+    """Validate that a question/answer pair is grounded in the source text."""
+
+    if not page_text or not question:
+        return False
+    if not isinstance(answerspan, tuple) or len(answerspan) != 2:
+        return False
+    try:
+        start = int(answerspan[0])
+        end = int(answerspan[1])
+    except (TypeError, ValueError):
+        return False
+    if start < 0 or end <= start or end > len(page_text):
+        return False
+    answer_text = page_text[start:end].strip()
+    if not answer_text:
+        return False
+
+    question_tokens = {tok for tok in _tokenize(question) if tok not in _STOPWORDS}
+    answer_tokens = {tok for tok in _tokenize(answer_text) if tok not in _STOPWORDS}
+    if not answer_tokens:
+        return False
+
+    if question_tokens & answer_tokens:
+        return True
+
+    slot_tokens: Set[str] = set()
+    for value in (slots or {}).values():
+        slot_tokens.update(_tokenize(value))
+    slot_tokens = {tok for tok in slot_tokens if tok not in _STOPWORDS}
+    if slot_tokens & answer_tokens:
+        return True
+
+    radius = 120
+    window_start = max(0, start - radius)
+    window_end = min(len(page_text), end + radius)
+    context_tokens = {
+        tok for tok in _tokenize(page_text[window_start:window_end]) if tok not in _STOPWORDS
+    }
+    if question_tokens & context_tokens:
+        return True
+
+    return False
+
+
+def enforce_wh_distribution(
+    questions: Sequence[str],
+    targets: Mapping[str, float],
+    seed: int,
+) -> List[str]:
+    """Subsample questions so that WH categories respect requested shares."""
+
+    if not questions:
+        return []
+
+    total = len(questions)
+    buckets: Dict[str, List[int]] = defaultdict(list)
+    for idx, question in enumerate(questions):
+        buckets[detect_wh(question)].append(idx)
+
+    rng = random.Random(seed)
+    selected: Set[int] = set()
+
+    for wh, indices in buckets.items():
+        share = targets.get(wh)
+        if share is None:
+            selected.update(indices)
+            continue
+        share = max(float(share), 0.0)
+        if share == 0.0:
+            continue
+        limit = math.ceil(total * share)
+        if limit <= 0:
+            limit = 1
+        limit = min(len(indices), limit)
+        if limit <= 0:
+            continue
+        shuffled = indices[:]
+        rng.shuffle(shuffled)
+        selected.update(shuffled[:limit])
+
+    for wh, indices in buckets.items():
+        if wh in targets and targets[wh] > 0 and indices:
+            if not any(idx in selected for idx in indices):
+                selected.add(indices[0])
+
+    if not selected:
+        return list(questions)
+
+    ordered = sorted(selected)
+    return [questions[idx] for idx in ordered]
+
+
+def mmr_select(
+    questions: Sequence[str],
+    context: str,
+    *,
+    k: int,
+    lambda_: float = 0.7,
+) -> List[str]:
+    """Select a diverse question subset via Maximal Marginal Relevance."""
+
+    if k <= 0 or not questions:
+        return []
+
+    context_tokens = {tok for tok in _tokenize(context) if tok not in _STOPWORDS}
+    question_tokens: List[Set[str]] = [
+        {tok for tok in _tokenize(q) if tok not in _STOPWORDS} for q in questions
+    ]
+
+    def _relevance(tokens: Set[str]) -> float:
+        if not tokens or not context_tokens:
+            return 0.0
+        return len(tokens & context_tokens) / float(len(tokens))
+
+    def _redundancy(idx: int, chosen: List[int]) -> float:
+        if not chosen:
+            return 0.0
+        current = question_tokens[idx]
+        if not current:
+            return 0.0
+        best = 0.0
+        for other in chosen:
+            other_tokens = question_tokens[other]
+            if not other_tokens:
+                continue
+            union = len(current | other_tokens)
+            if union == 0:
+                continue
+            overlap = len(current & other_tokens) / union
+            if overlap > best:
+                best = overlap
+        return best
+
+    selected: List[int] = []
+    remaining = list(range(len(questions)))
+
+    while remaining and len(selected) < k:
+        best_idx = None
+        best_score = float("-inf")
+        for idx in remaining:
+            relevance = _relevance(question_tokens[idx])
+            redundancy = _redundancy(idx, selected)
+            score = lambda_ * relevance - (1.0 - lambda_) * redundancy
+            if score > best_score:
+                best_score = score
+                best_idx = idx
+        if best_idx is None:
+            break
+        selected.append(best_idx)
+        remaining.remove(best_idx)
+
+    return [questions[idx] for idx in selected]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration ensuring the project root is importable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))


### PR DESCRIPTION
## Summary
- add defensive float coercion and shared parse batch helper so the UI can expose both compact and full outputs without type errors
- teach the chunk packer to fall back to a lightweight tokenizer and to emit sliding windows when block token counts exceed limits
- restore gold quality utilities including entity anchoring, answerability checking, WH balancing and MMR selection with a test-friendly conftest shim

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ced70102c48333b8456ca4a108db72