### PR TITLE
Revert overengineered fix and correct gold config

### DIFF
--- a/gold/llm_config.yaml
+++ b/gold/llm_config.yaml
@@ -3,8 +3,7 @@ model: "gpt-oss-20b"
 api_key_env: "VLLM_API_KEY"
 timeout_s: 60
 seed: 42
-temperature:
-  synth: 0.7
+temperature: 0.7
 limits:
   max_questions_per_window: 8
   synth_max_tokens: 900

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration ensuring the project root is importable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))


### PR DESCRIPTION
## Summary
- revert the prior "Improve offline robustness and gold utilities" changes that broke the pipeline
- set the gold llm temperature to a scalar 0.7 value so the configuration loads without type errors
- restore the gold quality helpers and pytest path shim required by the existing extraction and assembly flow

## Testing
- pytest *(fails: huggingface hub requests blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ced70102c48333b8456ca4a108db72