### PR TITLE
Normalize WH handling for updated synthesis prompt

### DIFF
--- a/gold/llm_synthesize.py
+++ b/gold/llm_synthesize.py
@@ -27,26 +27,18 @@ from gold.quality import (
     no_vague_pronoun,
     readability_bounds,
 )
-from gold.verify import SynthItem, parse_json_array, validate_synth_items
+from gold.verify import (
+    ALLOWED_WH,
+    SynthItem,
+    canonicalize_wh,
+    parse_json_array,
+    validate_synth_items,
+)
 from gold.window import make_windows
 
 logger = logging.getLogger(__name__)
 
 _CACHE_DIR = Path("gold/.cache")
-_ALLOWED_WH = {
-    "what",
-    "which",
-    "who",
-    "when",
-    "where",
-    "why",
-    "how",
-    "how_many",
-    "how_much",
-    "aux",
-}
-
-
 def load_config(path: Path) -> Dict:
     with path.open("r", encoding="utf-8") as fh:
         return yaml.safe_load(fh)
@@ -286,8 +278,8 @@ def _process_item(
     if not readability_bounds(question):
         raise _DropItem("readability")
 
-    wh = item.wh.strip().lower() if item.wh else detect_wh(question)
-    if wh not in _ALLOWED_WH:
+    wh = canonicalize_wh(item.wh) if item.wh else detect_wh(question)
+    if wh not in ALLOWED_WH:
         wh = detect_wh(question)
 
     record = {


### PR DESCRIPTION
## Summary
- expose and reuse the canonical list of allowed WH forms for synthesized questions
- normalize WH strings emitted by the new prompt so spaced variants map onto canonical tokens
- ensure synthesis fallback logic uses the shared normalization when vetting LLM outputs

## Testing
- `PYTHONPATH=. pytest` *(fails: repository is missing gold.quality.enforce_wh_distribution required by tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9c69910083338bef0568b6c4e762