### PR TITLE
Improve offline chunking and gold quality utilities

### DIFF
--- a/chunking/driver.py
+++ b/chunking/driver.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Sequence, Tuple
 
 from env_loader import load_dotenv_once
 
-from chunking.semantic_chunker import semantic_segments
+from chunking import semantic_chunker
 from chunking.segmenter import segment_page
 from chunking.types import Block, Chunk
 from chunking.packer import get_tokenizer, pack_blocks
@@ -60,7 +60,7 @@ def _semantic_or_fixed_blocks(
     if not semantic_enabled or table_heavy:
         return base_blocks, "fixed"
 
-    segments = semantic_segments(text, model_name=model_name)
+    segments = semantic_chunker.semantic_segments(text, model_name=model_name)
     if not segments:
         return base_blocks, "fixed"
 

--- a/gold/quality.py
+++ b/gold/quality.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import math
+import random
 import re
-from typing import Iterable, List, Sequence, Set
+from collections import defaultdict
+from typing import Dict, List, Mapping, Sequence, Set, Tuple
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
 
 _STOPWORDS: Set[str] = {
     "a",
@@ -85,26 +91,32 @@ def detect_wh(q: str) -> str:
     return "what"
 
 
-def is_entity_anchored(question: str, answer_text: str, window_text: str) -> bool:
+def is_entity_anchored(
+    question: str,
+    context: Mapping[str, str] | str,
+    window_text: str | None = None,
+) -> bool:
+    """Return ``True`` when question terms overlap with answer/context tokens."""
+
     q_tokens = [tok for tok in _tokenize(question) if tok not in _STOPWORDS]
     if not q_tokens:
         return False
-    answer_tokens = [tok for tok in _tokenize(answer_text) if tok not in _STOPWORDS]
-    overlap = set(q_tokens) & set(answer_tokens)
-    if overlap:
-        return True
-    # Fall back to local context around the first occurrence of the answer
-    answer_norm = answer_text.strip().lower()
-    if not answer_norm:
-        return False
-    idx = window_text.lower().find(answer_norm)
-    if idx == -1:
-        return False
-    radius = 100
-    start = max(0, idx - radius)
-    end = min(len(window_text), idx + len(answer_text) + radius)
-    context_tokens = [tok for tok in _tokenize(window_text[start:end]) if tok not in _STOPWORDS]
-    return bool(set(q_tokens) & set(context_tokens))
+
+    sources: List[str] = []
+    if isinstance(context, Mapping):
+        sources.extend(str(value) for value in context.values())
+    else:
+        sources.append(str(context))
+    if window_text:
+        sources.append(window_text)
+
+    for source in sources:
+        if not source:
+            continue
+        tokens = [tok for tok in _tokenize(source) if tok not in _STOPWORDS]
+        if set(q_tokens) & set(tokens):
+            return True
+    return False
 
 
 def has_banned_opening(question: str, banned: Sequence[str]) -> bool:
@@ -119,6 +131,12 @@ def no_vague_pronoun(question: str) -> bool:
     return tokens[0] not in _PRONOUN_HEADS
 
 
+def no_vague_pronouns(question: str) -> bool:
+    """Compatibility wrapper returning :func:`no_vague_pronoun`."""
+
+    return no_vague_pronoun(question)
+
+
 def readability_bounds(question: str, min_len: int = 8, max_len: int = 160) -> bool:
     stripped = question.strip()
     if not stripped.endswith("?"):
@@ -127,3 +145,185 @@ def readability_bounds(question: str, min_len: int = 8, max_len: int = 160) -> b
         return False
     words = stripped.split()
     return len(words) >= 3
+
+
+def answerability_check(
+    page_text: str,
+    span: Tuple[int, int],
+    question: str,
+    slots: Mapping[str, str] | None,
+) -> bool:
+    """Return ``True`` when the span/question pair is answerable on the page.
+
+    The heuristics intentionally stay light-weight so they can run during test
+    fixtures without additional dependencies. We require:
+
+    * a valid, non-empty span inside ``page_text``;
+    * a question containing at least one meaningful token; and
+    * lexical overlap between the question and either the answer span or the
+      extracted slot metadata.
+
+    These checks catch obvious failures (e.g. span mismatch, vague questions)
+    while remaining permissive enough for synthetic fixtures.
+    """
+
+    if not isinstance(span, (tuple, list)) or len(span) != 2:
+        return False
+    try:
+        start = int(span[0])
+        end = int(span[1])
+    except (TypeError, ValueError):
+        return False
+    if start < 0 or end <= start:
+        return False
+    if start >= len(page_text) or end > len(page_text):
+        return False
+
+    answer = page_text[start:end].strip()
+    if not answer:
+        return False
+
+    q_tokens = [tok for tok in _tokenize(question) if tok not in _STOPWORDS]
+    if not q_tokens:
+        return False
+
+    slots = slots or {}
+    slot_tokens = [tok for tok in _tokenize(" ".join(slots.values())) if tok not in _STOPWORDS]
+    answer_tokens = [tok for tok in _tokenize(answer) if tok not in _STOPWORDS]
+
+    vocabulary = set(slot_tokens) | set(answer_tokens)
+    if vocabulary & set(q_tokens):
+        return True
+
+    doc_hint = slots.get("doc_name") or slots.get("heading")
+    if doc_hint and doc_hint.lower() in question.lower():
+        return True
+
+    return False
+
+
+def _normalise_question(question: str) -> str:
+    return question.strip()
+
+
+def _unique_questions(questions: Sequence[str]) -> List[str]:
+    seen: Set[str] = set()
+    ordered: List[str] = []
+    for question in questions:
+        normalised = _normalise_question(question)
+        if not normalised:
+            continue
+        key = normalised.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered.append(normalised)
+    return ordered
+
+
+def enforce_wh_distribution(
+    questions: Sequence[str],
+    targets: Mapping[str, float],
+    seed: int = 0,
+) -> List[str]:
+    """Trim questions so WH buckets respect the configured proportions."""
+
+    unique_questions = _unique_questions(questions)
+    if not unique_questions or not targets:
+        return unique_questions
+
+    total = len(unique_questions)
+    grouped: Dict[str, List[int]] = defaultdict(list)
+    for idx, question in enumerate(unique_questions):
+        grouped[detect_wh(question)].append(idx)
+
+    rng = random.Random(seed)
+    selected_indices: Set[int] = set()
+
+    for wh, indices in grouped.items():
+        share = targets.get(wh)
+        if share is None:
+            selected_indices.update(indices)
+            continue
+        limit = int(math.ceil(total * max(share, 0.0)))
+        if limit <= 0:
+            continue
+        if len(indices) <= limit:
+            selected_indices.update(indices)
+            continue
+        shuffled = indices[:]
+        rng.shuffle(shuffled)
+        chosen = sorted(shuffled[:limit])
+        selected_indices.update(chosen)
+
+    if not selected_indices:
+        return unique_questions[:1]
+
+    return [unique_questions[idx] for idx in sorted(selected_indices)]
+
+
+def mmr_select(
+    candidates: Sequence[str],
+    reference_text: str,
+    *,
+    k: int,
+    lambda_: float = 0.7,
+) -> List[str]:
+    """Select up to ``k`` diverse questions using Maximal Marginal Relevance."""
+
+    unique_candidates = _unique_questions(candidates)
+    if not unique_candidates or k <= 0:
+        return []
+    if len(unique_candidates) <= k:
+        return unique_candidates
+
+    lambda_ = float(lambda_)
+    if not (0.0 < lambda_ <= 1.0):
+        lambda_ = 0.7
+
+    corpus = unique_candidates + [reference_text or ""]
+    vectorizer = TfidfVectorizer(stop_words="english")
+    matrix = vectorizer.fit_transform(corpus)
+    questions_matrix = matrix[:-1]
+    reference_vector = matrix[-1]
+
+    if reference_vector.nnz:
+        relevance_scores = cosine_similarity(questions_matrix, reference_vector).ravel().tolist()
+    else:
+        relevance_scores = [0.0] * len(unique_candidates)
+
+    candidate_indices = list(range(len(unique_candidates)))
+    selected: List[int] = []
+
+    while candidate_indices and len(selected) < k:
+        best_idx = None
+        best_score = -float("inf")
+        for idx in candidate_indices:
+            relevance_score = float(relevance_scores[idx])
+            redundancy = 0.0
+            if selected:
+                sims = cosine_similarity(questions_matrix[idx], questions_matrix[selected])
+                redundancy = float(sims.max()) if sims.size else 0.0
+            score = lambda_ * relevance_score - (1.0 - lambda_) * redundancy
+            if score > best_score:
+                best_score = score
+                best_idx = idx
+        if best_idx is None:
+            break
+        selected.append(best_idx)
+        candidate_indices.remove(best_idx)
+
+    return [unique_candidates[idx] for idx in selected]
+
+
+__all__ = [
+    "answerability_check",
+    "detect_wh",
+    "enforce_wh_distribution",
+    "has_banned_opening",
+    "is_entity_anchored",
+    "mmr_select",
+    "no_vague_pronoun",
+    "no_vague_pronouns",
+    "readability_bounds",
+]


### PR DESCRIPTION
## Summary
- add the missing gold quality utilities used by tests, including answerability checks, WH distribution shaping, and MMR-based question selection
- make the chunking stack friendlier to offline environments by falling back to a whitespace tokenizer, handling semantic chunker failures, and ensuring long blocks still produce multiple windows
- keep the app parse callback compatible with tests while exposing the extended output set to the UI

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfbafae8a48333bb910655f06fea37