### PR TITLE
Update evidence handling for synthesized questions

### DIFF
--- a/gold/build_gold_llm.py
+++ b/gold/build_gold_llm.py
@@ -74,14 +74,16 @@ def _write_stats(
         counts: Counter[str] = Counter()
         for item in items:
             for entry in item.get("evidence", []) or []:
+                if isinstance(entry, str):
+                    if entry.strip():
+                        counts["text"] += 1
+                    continue
                 if isinstance(entry, dict):
                     ev_type = entry.get("type")
-                else:
-                    ev_type = None
-                if isinstance(ev_type, str):
-                    ev_value = ev_type.strip().lower()
-                    if ev_value:
-                        counts[ev_value] += 1
+                    if isinstance(ev_type, str):
+                        ev_value = ev_type.strip().lower()
+                        if ev_value:
+                            counts[ev_value] += 1
         return counts
 
     candidate_evidence = _evidence_counter(candidates)

--- a/gold/judge.py
+++ b/gold/judge.py
@@ -53,11 +53,23 @@ def _summarize_evidence(
     fallback_spans: Optional[Sequence[Tuple[int, int]]] = None,
 ) -> str:
     sentence_bounds = _sentence_spans(window_text)
-    spans = _resolve_evidence_spans(evidence_entries or [], sentence_bounds)
+    spans = _resolve_evidence_spans(evidence_entries or [], sentence_bounds, window_text)
     snippets = _render_snippets(window_text, spans)
 
     if not snippets and fallback_spans:
         snippets = _render_snippets(window_text, fallback_spans)
+
+    if not snippets and evidence_entries:
+        raw_lines = []
+        for idx, entry in enumerate(evidence_entries, start=1):
+            if isinstance(entry, str):
+                text = entry.strip()
+            else:
+                text = ""
+            if text:
+                raw_lines.append(f"{idx}. {text}")
+        if raw_lines:
+            snippets = raw_lines
 
     if not snippets:
         return "No evidence snippets available."

--- a/gold/spans.py
+++ b/gold/spans.py
@@ -6,6 +6,7 @@ import re
 from typing import Any, Iterable, List, Optional, Sequence, Tuple
 
 _SENTENCE_REGEX = re.compile(r"[^.!?\n]+(?:[.!?]+|\n+|$)")
+_WS_RE = re.compile(r"\s+")
 
 
 def sentence_spans(text: str) -> List[Tuple[int, int]]:
@@ -29,6 +30,91 @@ def sentence_spans(text: str) -> List[Tuple[int, int]]:
     return spans
 
 
+def resolve_evidence_spans(
+    evidence: Iterable[Any],
+    sentence_bounds: Sequence[Tuple[int, int]],
+    window_text: str,
+) -> List[Tuple[int, int]]:
+    """Approximate evidence spans using ``window_text`` and ``sentence_bounds``."""
+
+    spans: List[Tuple[int, int]] = []
+    if not window_text:
+        return spans
+
+    normalized_text, index_map = _normalize_with_mapping(window_text)
+    if not normalized_text:
+        return spans
+
+    sentence_norms: List[Tuple[str, Tuple[int, int]]] = []
+    for start, end in sentence_bounds:
+        if start >= end:
+            continue
+        snippet = window_text[start:end]
+        norm = _normalize(snippet)
+        if not norm:
+            continue
+        sentence_norms.append((norm, (start, end)))
+
+    seen: set[Tuple[int, int]] = set()
+    search_start = 0
+    bounds_len = len(sentence_bounds)
+
+    for entry in evidence:
+        text = _extract_text(entry)
+        span: Optional[Tuple[int, int]] = None
+        next_search_start = search_start
+
+        if text:
+            normalized_entry = _normalize(text)
+            if normalized_entry:
+                idx = normalized_text.find(normalized_entry, search_start)
+                if idx == -1:
+                    idx = normalized_text.find(normalized_entry)
+                if idx != -1:
+                    span = _span_from_mapping(index_map, idx, len(normalized_entry))
+                    if span is not None:
+                        next_search_start = idx + len(normalized_entry)
+                if span is None:
+                    for sentence_norm, sentence_span in sentence_norms:
+                        if normalized_entry in sentence_norm:
+                            span = sentence_span
+                            break
+        else:
+            idx = _extract_index(entry)
+            if idx is not None and 0 <= idx < bounds_len:
+                span = sentence_bounds[idx]
+
+        search_start = next_search_start
+
+        if span is None:
+            continue
+        start, end = span
+        if start >= end:
+            continue
+        key = (start, end)
+        if key in seen:
+            continue
+        seen.add(key)
+        spans.append((start, end))
+
+    return spans
+
+
+def _extract_text(entry: Any) -> Optional[str]:
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, dict):
+        value = entry.get("text") or entry.get("snippet")
+        if isinstance(value, str):
+            return value
+    else:
+        for attr in ("text", "snippet"):
+            value = getattr(entry, attr, None)
+            if isinstance(value, str):
+                return value
+    return None
+
+
 def _extract_index(entry: Any) -> Optional[int]:
     if isinstance(entry, dict):
         value = entry.get("index")
@@ -45,27 +131,45 @@ def _extract_index(entry: Any) -> Optional[int]:
         return None
 
 
-def resolve_evidence_spans(
-    evidence: Iterable[Any],
-    sentence_bounds: Sequence[Tuple[int, int]],
-) -> List[Tuple[int, int]]:
-    """Map evidence indices to character spans using ``sentence_bounds``."""
+def _normalize(text: str) -> str:
+    return _WS_RE.sub(" ", text).strip().lower()
 
-    spans: List[Tuple[int, int]] = []
-    seen: set[Tuple[int, int]] = set()
-    bounds_len = len(sentence_bounds)
 
-    for entry in evidence:
-        idx = _extract_index(entry)
-        if idx is None or idx < 0 or idx >= bounds_len:
+def _normalize_with_mapping(text: str) -> Tuple[str, List[int]]:
+    normalized: List[str] = []
+    index_map: List[int] = []
+    last_was_space = True
+
+    for idx, char in enumerate(text):
+        if char.isspace():
+            if last_was_space:
+                continue
+            normalized.append(" ")
+            index_map.append(idx)
+            last_was_space = True
             continue
-        span = sentence_bounds[idx]
-        if span in seen:
-            continue
-        seen.add(span)
-        spans.append(span)
+        normalized.append(char.lower())
+        index_map.append(idx)
+        last_was_space = False
 
-    return spans
+    if normalized and normalized[-1] == " ":
+        normalized.pop()
+        index_map.pop()
+
+    return "".join(normalized), index_map
+
+
+def _span_from_mapping(index_map: Sequence[int], start_idx: int, length: int) -> Optional[Tuple[int, int]]:
+    if length <= 0 or start_idx < 0:
+        return None
+    end_idx = start_idx + length - 1
+    if end_idx >= len(index_map):
+        return None
+    start = index_map[start_idx]
+    end = index_map[end_idx] + 1
+    if start >= end:
+        return None
+    return start, end
 
 
 __all__ = ["sentence_spans", "resolve_evidence_spans"]

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -46,7 +46,7 @@ def make_record() -> dict:
         "wh": "what",
         "type": "definitional",
         "answer_text": "It covers data retention requirements.",
-        "evidence": [{"type": "sentence", "index": 0}],
+        "evidence": ["The policy covers data retention requirements."],
         "char_start": 4,
         "char_end": 42,
         "window_text": window_text,

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -1,0 +1,41 @@
+from gold.spans import resolve_evidence_spans, sentence_spans
+
+
+def test_resolve_evidence_spans_handles_whitespace_and_case() -> None:
+    window_text = "The Policy covers data   retention requirements.\nIt applies company-wide."
+    sentences = sentence_spans(window_text)
+    evidence = ["  the policy covers DATA retention  requirements.  "]
+
+    spans = resolve_evidence_spans(evidence, sentences, window_text)
+
+    assert spans, "Expected at least one span"
+    start, end = spans[0]
+    expected_snippet = "The Policy covers data   retention requirements."
+    expected_start = window_text.index(expected_snippet)
+    expected_end = expected_start + len(expected_snippet)
+    assert (start, end) == (expected_start, expected_end)
+
+
+def test_resolve_evidence_spans_matches_across_newlines() -> None:
+    window_text = "Responsibilities:\n- Maintain systems\n- Report outages"
+    sentences = sentence_spans(window_text)
+    evidence = ["Responsibilities: - Maintain systems"]
+
+    spans = resolve_evidence_spans(evidence, sentences, window_text)
+
+    assert spans, "Expected evidence span for newline-normalised text"
+    expected_snippet = "Responsibilities:\n- Maintain systems"
+    expected_start = window_text.index(expected_snippet)
+    expected_end = expected_start + len(expected_snippet)
+    assert spans[0] == (expected_start, expected_end)
+
+
+def test_resolve_evidence_spans_supports_index_fallback() -> None:
+    window_text = "First sentence. Second sentence with Evidence. Third one."
+    sentences = sentence_spans(window_text)
+    assert len(sentences) >= 3
+    evidence = [{"index": 1}]
+
+    spans = resolve_evidence_spans(evidence, sentences, window_text)
+
+    assert spans == [sentences[1]]

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -10,7 +10,7 @@ def _make_payload(question: str) -> dict:
         "wh": "what",
         "type": "definitional",
         "answer_text": "Data retention policy",
-        "evidence": [{"type": "sentence", "index": 0}],
+        "evidence": ["The policy covers data retention requirements."],
     }
 
 


### PR DESCRIPTION
## Summary
- treat synthesized evidence as verbatim text snippets throughout validation and synthesis
- resolve evidence spans by matching normalized snippets against window text and surface raw snippets to the judge when alignment fails
- update stats and tests to exercise the new evidence format and span normalization logic

## Testing
- PYTHONPATH=. pytest tests/test_spans.py tests/test_verify.py tests/test_judge.py

------
https://chatgpt.com/codex/tasks/task_e_68d103516df083338e23bbb4e1a263c5